### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete multi-character sanitization

### DIFF
--- a/src/utils/noteUtils.ts
+++ b/src/utils/noteUtils.ts
@@ -69,7 +69,12 @@ export function sanitizeContent(content: string): string {
   )
 
   // Remove event handlers (onclick, onerror, etc.)
-  sanitized = sanitized.replace(/\son\w+\s*=\s*["'][^"']*["']/gi, '')
+  // Repeat the replacement until no changes are made
+  let prevSanitized;
+  do {
+    prevSanitized = sanitized;
+    sanitized = sanitized.replace(/\son\w+\s*=\s*["'][^"']*["']/gi, '');
+  } while (prevSanitized !== sanitized);
 
   // Remove javascript: protocol
   sanitized = sanitized.replace(/javascript:/gi, '')


### PR DESCRIPTION
Potential fix for [https://github.com/shazzar00ni/paperlyte/security/code-scanning/8](https://github.com/shazzar00ni/paperlyte/security/code-scanning/8)

To fix the incomplete multi-character sanitization at line 72 of `src/utils/noteUtils.ts`, the best approach is to repeatedly apply the replacement for event handler attributes until no further replacements occur. This prevents crafted inputs from circumventing the sanitization logic. The fix should be localized to the `sanitizeContent` function, specifically where event handler attributes are removed. There is no need to change the regular expression or import new libraries, but the code removing event handlers should be changed to apply the replacement in a loop. This change preserves all existing functionality and ensures no `on*` handlers survive in the sanitized output.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
