### PR TITLE
Potential fix for code scanning alert no. 12: Incomplete multi-character sanitization

### DIFF
--- a/src/utils/sanitization.ts
+++ b/src/utils/sanitization.ts
@@ -32,11 +32,16 @@ export function sanitizeTitle(title: string): string {
     originalLength,
   })
 
-  // Remove script tags with their content first
-  let sanitized = title.replace(
-    /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,
-    ''
-  )
+  // Remove script tags with their content first (apply repeatedly for complete removal)
+  let sanitized = title;
+  let previous;
+  do {
+    previous = sanitized;
+    sanitized = sanitized.replace(
+      /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,
+      ''
+    );
+  } while (sanitized !== previous);
 
   const hasScriptTags = sanitized.length !== title.length
   if (hasScriptTags) {


### PR DESCRIPTION
Potential fix for [https://github.com/shazzar00ni/paperlyte/security/code-scanning/12](https://github.com/shazzar00ni/paperlyte/security/code-scanning/12)

The best fix is to apply the script tag removal regex repeatedly until no further changes are made to ensure all occurrences, including fragmented or nested ones, are removed. That is, keep applying the multi-character replacement until the string stabilizes. This prevents incomplete removals caused by overlapping or sequential dangerous patterns. Ideally, one would use a well-vetted library like `sanitize-html`, but as the code currently uses only custom regexes for minimal title cleaning, the looped approach is sufficient.

**How to fix:**
- Replace lines 36–39 with a loop that repeatedly applies the script tag removal until no further script tags remain.
- Preserve the monitoring logic that tracks whether script tags were removed.

This change is localized to the `sanitizeTitle` function in `src/utils/sanitization.ts`. No new imports or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
